### PR TITLE
IndirectY doesn't count cycles properly

### DIFF
--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -32,7 +32,7 @@ export default class CPU {
    */
   public Registers = new Registers();
 
-  /** 
+  /**
    * The status flags
    */
   public Flags = new Flags();
@@ -135,10 +135,12 @@ export default class CPU {
         this.consumedCycles++;
         // Read the base address from the zero page location
         const baseAddress = memory.readWord(zeroPageAddress);
-        this.consumedCycles += 2;
+        this.consumedCycles += 1;
         // Add the value of the Y register.
         const dataAddress = baseAddress + this.Registers.Y;
         this.consumedCycles++;
+        // Check and see if the addition crosses a page boundary
+        if (memory.OffsetCrossesPageBoundary(baseAddress, this.Registers.Y)) this.consumedCycles++;
         // Actually read the data.
         data = memory.readByte(dataAddress);
         this.consumedCycles++;

--- a/tests/lda.test.ts
+++ b/tests/lda.test.ts
@@ -316,10 +316,20 @@ test("Verify LDA Indirect Y", () => {
   memory.writeByte(CODE_LOCATION, Opcodes.LDA_IndirectY);
   memory.writeByte(CODE_LOCATION + 1, 0x86); // This is the zero page address
   memory.writeWord(0x86, 0x4028); // This is the base memory location of the data
-  cpu.Registers.Y = 0x10; // This is the offset to add to the value stored in the zero page address location
 
   // Positive non-zero number case, memory location doesn't wrap zero page
+  cpu.Registers.Y = 0x10; // This is the offset to add to the value in the base memory location
   memory.writeWord(0x4028 + 0x10, 0x42); // This is the actual data to read
+  expect(cpu.Execute(5, memory)).toBe(5);
+  expect(cpu.Registers.A).toBe(0x42);
+  expect(cpu.Flags.Z).toBe(false);
+  expect(cpu.Flags.N).toBe(false);
+  expect(cpu.PC).toBe(CODE_LOCATION + 2);
+
+  // Positive non-zero number case, memory location crosses page boundary
+  cpu.Initialize(memory);
+  cpu.Registers.Y = 0xff; // This is the offset to add to the value stored in the zero page address location
+  memory.writeWord(0x4028 + 0xff, 0x42); // This is the actual data to read
   expect(cpu.Execute(6, memory)).toBe(6);
   expect(cpu.Registers.A).toBe(0x42);
   expect(cpu.Flags.Z).toBe(false);
@@ -328,8 +338,9 @@ test("Verify LDA Indirect Y", () => {
 
   // Zero number case
   cpu.Initialize(memory);
+  cpu.Registers.Y = 0x10; // This is the offset to add to the value stored in the zero page address location
   memory.writeWord(0x4028 + 0x10, 0x00); // This is the actual data to read
-  expect(cpu.Execute(6, memory)).toBe(6);
+  expect(cpu.Execute(5, memory)).toBe(5);
   expect(cpu.Registers.A).toBe(0x00);
   expect(cpu.Flags.Z).toBe(true);
   expect(cpu.Flags.N).toBe(false);
@@ -337,8 +348,9 @@ test("Verify LDA Indirect Y", () => {
 
   // Negative number case, memory location doesn't wrap zero page
   cpu.Initialize(memory);
+  cpu.Registers.Y = 0x10; // This is the offset to add to the value stored in the zero page address location
   memory.writeWord(0x4028 + 0x10, 0b10010101); // This is the actual data to read
-  expect(cpu.Execute(6, memory)).toBe(6);
+  expect(cpu.Execute(5, memory)).toBe(5);
   expect(cpu.Registers.A).toBe(0b10010101);
   expect(cpu.Flags.Z).toBe(false);
   expect(cpu.Flags.N).toBe(true);

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -78,4 +78,4 @@ test("Verify clear", () => {
   memory.writeByte(0x00, 0x42);
   memory.Clear();
   expect(memory.readByte(0x00)).toBe(0x00);
-})
+});


### PR DESCRIPTION
Fixes #9

Added page boundary check to IndirectY address mode and additional unit tests.